### PR TITLE
Added support for calling non-thread safe plugins so they can be used in multi-threaded builds.

### DIFF
--- a/mojo-executor-maven-plugin/pom.xml
+++ b/mojo-executor-maven-plugin/pom.xml
@@ -94,7 +94,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
                 <configuration>
-                    <!-- <debug>true</debug> -->
+<!--                     <debug>true</debug>-->
                     <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
                     <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
                     <settingsFile>src/it/settings.xml</settingsFile>

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-blocking/pom.xml
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-blocking/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2008-2013 Don Brown
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.twdata.maven</groupId>
+    <artifactId>mojo-executor-test-project-blocking</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>Mojo Executor - Test Project</name>
+    <description>
+        Used by the tests for the Mojo Executor Maven Plugin.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.4</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <version>1.7.4</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit-dep</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.twdata.maven</groupId>
+                <artifactId>mojo-executor-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>execute-mojo</goal>
+                        </goals>
+                        <configuration>
+                            <quiet>false</quiet>
+                            <blocking>true</blocking>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-dependency-plugin</artifactId>
+                                <version>2.0</version>
+                            </plugin>
+                            <goal>list</goal>
+                            <configuration>
+                            </configuration>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-blocking/postbuild.groovy
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-blocking/postbuild.groovy
@@ -16,16 +16,10 @@
 File buildLog = new File((String) basedir, "build.log")
 def text = buildLog.getText()
 text = text.replaceAll("\r\n", "\n")
-def verify = text.contains("""
-[INFO] Executing 'org.apache.maven.plugins:maven-dependency-plugin' in blocking mode.
-[INFO] 
-[INFO] The following files have been resolved:
+def v1 = text.contains("[INFO] Executing 'org.apache.maven.plugins:maven-dependency-plugin' in blocking mode.")
+def v2 = text.contains("""[INFO] The following files have been resolved:
 [INFO]    junit:junit:jar:4.11:test
 [INFO]    org.hamcrest:hamcrest-core:jar:1.3:test
 [INFO]    org.slf4j:slf4j-api:jar:1.7.4:provided
-[INFO]    org.slf4j:slf4j-nop:jar:1.7.4:runtime
-[INFO] 
-[INFO] Released 'org.apache.maven.plugins:maven-dependency-plugin' block.
-""");
-
-return verify;
+[INFO]    org.slf4j:slf4j-nop:jar:1.7.4:runtime""");
+return v1 && v2;

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-blocking/postbuild.groovy
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-blocking/postbuild.groovy
@@ -16,10 +16,16 @@
 File buildLog = new File((String) basedir, "build.log")
 def text = buildLog.getText()
 text = text.replaceAll("\r\n", "\n")
-return ! text.contains("""
+def verify = text.contains("""
+[INFO] Executing 'org.apache.maven.plugins:maven-dependency-plugin' in blocking mode.
+[INFO] 
 [INFO] The following files have been resolved:
 [INFO]    junit:junit:jar:4.11:test
 [INFO]    org.hamcrest:hamcrest-core:jar:1.3:test
 [INFO]    org.slf4j:slf4j-api:jar:1.7.4:provided
 [INFO]    org.slf4j:slf4j-nop:jar:1.7.4:runtime
+[INFO] 
+[INFO] Released 'org.apache.maven.plugins:maven-dependency-plugin' block.
 """);
+
+return verify;

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-no-plugin-version/postbuild.groovy
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-no-plugin-version/postbuild.groovy
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 File buildLog = new File((String) basedir, "build.log")
-return buildLog.getText().contains("""
+def text = buildLog.getText()
+text = text.replaceAll("\r\n", "\n")
+return text.contains("""
 [INFO] The following files have been resolved:
 [INFO]    junit:junit:jar:4.11:test
 [INFO]    org.hamcrest:hamcrest-core:jar:1.3:test

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-null-maven-project/postbuild.groovy
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-null-maven-project/postbuild.groovy
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 File buildLog = new File((String) basedir, "build.log")
-return buildLog.getText().contains("""
+def text = buildLog.getText()
+text = text.replaceAll("\r\n", "\n")
+return text.contains("""
 [INFO] The following files have been resolved:
 [INFO]    junit:junit:jar:4.11:test
 [INFO]    org.hamcrest:hamcrest-core:jar:1.3:test

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project/postbuild.groovy
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project/postbuild.groovy
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 File buildLog = new File((String) basedir, "build.log")
-return buildLog.getText().contains("""
+def text = buildLog.getText()
+text = text.replaceAll("\r\n", "\n")
+return text.contains("""
 [INFO] The following files have been resolved:
 [INFO]    junit:junit:jar:4.11:test
 [INFO]    org.hamcrest:hamcrest-core:jar:1.3:test

--- a/mojo-executor-maven-plugin/src/main/java/org/twdata/maven/mojoexecutor/plugin/MojoExecutorMojo.java
+++ b/mojo-executor-maven-plugin/src/main/java/org/twdata/maven/mojoexecutor/plugin/MojoExecutorMojo.java
@@ -23,17 +23,17 @@ import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.plugins.annotations.*;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
 import org.codehaus.plexus.logging.Logger;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.lang.String.format;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
 import static org.twdata.maven.mojoexecutor.PlexusConfigurationUtils.toXpp3Dom;
@@ -42,18 +42,20 @@ import static org.twdata.maven.mojoexecutor.PlexusConfigurationUtils.toXpp3Dom;
  * Execute a Mojo using the MojoExecutor.
  */
 @SuppressWarnings("unused")
-@Mojo( name = "execute-mojo", defaultPhase = LifecyclePhase.TEST, requiresDependencyResolution = ResolutionScope.TEST)
+@Mojo(name = "execute-mojo", defaultPhase = LifecyclePhase.TEST, requiresDependencyResolution = ResolutionScope.TEST)
 public class MojoExecutorMojo extends AbstractMojo {
+    private static final Set<String> lockedKeys = new HashSet<>();
+
     /**
      * Plugin to execute.
      */
-    @Parameter (required = true)
+    @Parameter(required = true)
     private Plugin plugin;
 
     /**
      * Plugin goal to execute.
      */
-    @Parameter (required = true)
+    @Parameter(required = true)
     private String goal;
 
     /**
@@ -65,13 +67,13 @@ public class MojoExecutorMojo extends AbstractMojo {
     /**
      * The project currently being build.
      */
-    @Parameter( defaultValue = "${project}", readonly = true )
+    @Parameter(defaultValue = "${project}", readonly = true)
     private MavenProject mavenProject;
 
     /**
      * The current Maven session.
      */
-    @Parameter( defaultValue = "${session}", readonly = true )
+    @Parameter(defaultValue = "${session}", readonly = true)
     private MavenSession mavenSession;
 
     /**
@@ -83,27 +85,63 @@ public class MojoExecutorMojo extends AbstractMojo {
     /**
      * Disable logging on executed mojos
      */
-    @Parameter ( defaultValue = "false")
+    @Parameter(defaultValue = "false")
     private boolean quiet;
+
+    /**
+     * Enable thread blocking per plugin GA (groupId & artifactId)
+     */
+    @Parameter(defaultValue = "false")
+    private boolean blocking;
 
     /**
      * Ignore injected maven projetc
      */
-    @Parameter ( defaultValue = "false")
+    @Parameter(defaultValue = "false")
     private boolean ignoreMavenProject;
 
     public void execute() throws MojoExecutionException {
 
         getLog().info("Executing with maven project " + mavenProject + " for session " + mavenSession);
 
-        if ( quiet )
-        {
+        if (quiet) {
             disableLogging();
         }
+
+        // Blocking case.
+        if (blocking) {
+            final String key = format("%s:%s", plugin.getGroupId(), plugin.getArtifactId());
+
+            try {
+                lock(key);
+
+                getLog().info(String.format("Executing '%s' in blocking mode.", key));
+
+                //Put your code here.
+                //For different keys it is executed in parallel.
+                //For equal keys it is executed synchronously.
+                executeMojoImpl();
+
+            } catch (InterruptedException e) {
+                final String failed = "Failed to execute mojo";
+                getLog().error(failed, e);
+                throw new MojoExecutionException(failed, e);
+            } finally {
+                unlock(key);
+
+                getLog().info(String.format("Released '%s' block.", key));
+            }
+        } else {
+            // Non blocking case.
+            executeMojoImpl();
+        }
+    }
+
+    private void executeMojoImpl() throws MojoExecutionException {
         executeMojo(plugin, goal, toXpp3Dom(configuration),
-            (ignoreMavenProject ?
-                executionEnvironment( mavenSession, pluginManager) :
-                executionEnvironment( mavenProject, mavenSession, pluginManager)));
+                (ignoreMavenProject ?
+                        executionEnvironment(mavenSession, pluginManager) :
+                        executionEnvironment(mavenProject, mavenSession, pluginManager)));
     }
 
     private void disableLogging() throws MojoExecutionException {
@@ -121,5 +159,20 @@ public class MojoExecutorMojo extends AbstractMojo {
         Slf4jConfiguration slf4jConfiguration = Slf4jConfigurationFactory.getConfiguration(slf4jLoggerFactory);
         slf4jConfiguration.setRootLoggerLevel(Slf4jConfiguration.Level.ERROR);
         slf4jConfiguration.activate();
+    }
+
+    private void lock(String key) throws InterruptedException {
+        synchronized (lockedKeys) {
+            while (!lockedKeys.add(key)) {
+                lockedKeys.wait();
+            }
+        }
+    }
+
+    private void unlock(String key) {
+        synchronized (lockedKeys) {
+            lockedKeys.remove(key);
+            lockedKeys.notifyAll();
+        }
     }
 }


### PR DESCRIPTION
Added support for calling non-thread safe wrapped plugins in a thread blocking manor so they can be used in builds that require usage of multiple threads.  Also fixed IT tests so they can run on Windows platform.