### PR TITLE
Updated groovy postbuild to support windows platform

### DIFF
--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-no-plugin-version/postbuild.groovy
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-no-plugin-version/postbuild.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 File buildLog = new File((String) basedir, "build.log")
-return buildLog.getText().contains("""
+return buildLog.getText().replace("\r\n","\n").contains("""
 [INFO] The following files have been resolved:
 [INFO]    junit:junit:jar:4.11:test
 [INFO]    org.hamcrest:hamcrest-core:jar:1.3:test

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-null-maven-project/postbuild.groovy
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-null-maven-project/postbuild.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 File buildLog = new File((String) basedir, "build.log")
-return buildLog.getText().contains("""
+return buildLog.getText().replace("\r\n","\n").contains("""
 [INFO] The following files have been resolved:
 [INFO]    junit:junit:jar:4.11:test
 [INFO]    org.hamcrest:hamcrest-core:jar:1.3:test

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-quiet/postbuild.groovy
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-quiet/postbuild.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 File buildLog = new File((String) basedir, "build.log")
-return ! buildLog.getText().contains("""
+return ! buildLog.getText().replace("\r\n","\n").contains("""
 [INFO] The following files have been resolved:
 [INFO]    junit:junit:jar:4.11:test
 [INFO]    org.hamcrest:hamcrest-core:jar:1.3:test

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project/postbuild.groovy
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project/postbuild.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 File buildLog = new File((String) basedir, "build.log")
-return buildLog.getText().contains("""
+return buildLog.getText().replace("\r\n","\n").contains("""
 [INFO] The following files have been resolved:
 [INFO]    junit:junit:jar:4.11:test
 [INFO]    org.hamcrest:hamcrest-core:jar:1.3:test


### PR DESCRIPTION
If you add this pull request the IT test on mojo-executor-maven-plugin will work on windows and Linus.  This is because when windows output the log file, it adds cr/nl at the end and when groovy creates the multiline string to compare, it only appends a nl at the end. This pull request will change all cr/nl to nl to make it identical to linux and the groovy multiline string.